### PR TITLE
[feat / chore] Add routing for /search requests; move Yelp request to api_request folder  

### DIFF
--- a/server/config/middleware.js
+++ b/server/config/middleware.js
@@ -1,8 +1,12 @@
 var bodyParser = require('body-parser');
 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({extended:false}));
 
 module.exports = function(app, express) {
-   app.use(express.static(__dirname + '/../../client'));
- }
+
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({extended:false}));
+
+  app.use(express.static(__dirname + '/../../client'));
+
+
+};

--- a/server/config/middleware.js
+++ b/server/config/middleware.js
@@ -2,11 +2,17 @@ var bodyParser = require('body-parser');
 
 
 module.exports = function(app, express) {
+  var searchRouter = express.Router();
+  // var userRouter = express.Router();
+  // var eventRouter = express.Router();
 
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({extended:false}));
 
   app.use(express.static(__dirname + '/../../client'));
 
+  app.use('/api/search', searchRouter);
+
+  require('../search/search_router.js')(searchRouter);
 
 };

--- a/server/data/api_requests/api_router.js
+++ b/server/data/api_requests/api_router.js
@@ -1,4 +1,4 @@
-var Yelp = require('../../config/config.js');
+var Yelp = require('./restaurant_search.js');
 
 module.exports = {
 

--- a/server/data/api_requests/restaurant_search.js
+++ b/server/data/api_requests/restaurant_search.js
@@ -12,13 +12,12 @@ module.exports.askYelp = function(searchTerm, response) {
   yelp.search({category_filter:category, location:'boston'})
   .then(function(yelpData){
     response.status(200).json(yelpData.businesses);
+    // re-write to send response back to handle before sending to client 
   })
   .catch(function(err) {
     console.log("error inside config.js askYelp", err)
   })
 }
-
-
 
 
 /*

--- a/server/search/search_controller.js
+++ b/server/search/search_controller.js
@@ -1,0 +1,24 @@
+var api_router = require('./../data/api_requests/api_router.js');
+
+module.exports = {
+  handleSearch: function handleSearch(req, res) {
+    console.log('made it to handleSearch!')
+    // api_router.askYelp(req, res);
+  }
+
+  // things to do
+    // get in search (handleSearch)
+    // parse users search input
+    // determine from input what to ask yelp for
+        // logic logic logic (for mvp, this doesnt really need logic)
+    // make api request to yelp and get response
+        // this will use content of ./../data/api_requests/
+            // these must be readjusted to return a response here
+            // rather than immediately sending Yelps res to the client
+    // choose which responses to send back to the client
+        // logic logic logic
+    // send the selected options / resp back to the client
+}
+
+// search categories for MVP: Location, (3) Food Genres, Veg (y/n), by rating
+

--- a/server/search/search_router.js
+++ b/server/search/search_router.js
@@ -1,0 +1,10 @@
+var searchController = require('./search_controller.js');
+
+module.exports = function (app) {
+  // curr plain /search post request will search for restaurants
+    // however, having a search router would allow for other searches
+    // if we chose to expand beyond restaurants (activities, etc.)
+  app.route('/')
+    .post(searchController.handleSearch);
+
+};

--- a/server/server.js
+++ b/server/server.js
@@ -1,19 +1,8 @@
 var express = require('express');
 var app = express();
 
-var bodyParser = require('body-parser');
-
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({extended:false}));
-
 require('./config/middleware.js')(app, express);
 
-var api_router = require('./data/api_requests/api_router.js');
-
-
-app.post('/search', function (req, res) {
-  api_router.askYelp(req, res);
-})
 
 module.exports = app;
 


### PR DESCRIPTION
- moved body-parser middleware to middleware.js
- moved Yelp api request to api request folder 
- added in routing for /search request (routes to a file which will contain logic for processing user search input, requesting relevant options from external api, and responding to the client with options to present to user)