### PR TITLE
[feat] route client search request to Yelp api call; return resp

### DIFF
--- a/server/data/api_requests/api_router.js
+++ b/server/data/api_requests/api_router.js
@@ -2,8 +2,8 @@ var Yelp = require('./restaurant_search.js');
 
 module.exports = {
 
-  askYelp:function(req, res) {
-    Yelp.askYelp(req.body.searchTerm, res);
+  askYelp:function(searchCriteria, res) {
+    Yelp.askYelp(searchCriteria, res);
   }
 
 };

--- a/server/data/api_requests/restaurant_search.js
+++ b/server/data/api_requests/restaurant_search.js
@@ -7,15 +7,18 @@ var yelp = new Yelp({
   token_secret:'D4W6WFkDcsxrADvwLMcv3ZrDJdA'
 });
 
-module.exports.askYelp = function(searchTerm, response) {
-  var category = 'restaurants,' + searchTerm
-  yelp.search({category_filter:category, location:'boston'})
+module.exports.askYelp = function(searchCriteria, response) {
+  console.log('search criteria', searchCriteria);
+  // searchCriteria is an object with filter data
+    //will first pass in {searchTerm: 'some food type', location: 'some location'}
+  var category = 'restaurants,' + searchCriteria.searchTerm;
+  yelp.search({category_filter:category, location:searchCriteria.location})
   .then(function(yelpData){
     response.status(200).json(yelpData.businesses);
     // re-write to send response back to handle before sending to client 
   })
   .catch(function(err) {
-    console.log("error inside config.js askYelp", err)
+    console.log("error inside restaurant_search.js askYelp", err)
   })
 }
 

--- a/server/search/search_controller.js
+++ b/server/search/search_controller.js
@@ -1,9 +1,17 @@
 var api_router = require('./../data/api_requests/api_router.js');
 
-module.exports = {
+module.exports = searchControls = {
   handleSearch: function handleSearch(req, res) {
-    console.log('made it to handleSearch!')
-    // api_router.askYelp(req, res);
+    console.log('search req body', req.body)
+    searchControls.makeRequest(req.body, res);
+  },
+
+  makeRequest: function makeRequest(searchInput, res) {
+    var searchCriteria = {
+      location: searchInput.location,
+      searchTerm: searchInput.opt1 
+    };
+    api_router.askYelp(searchCriteria, res);
   }
 
   // things to do
@@ -20,5 +28,15 @@ module.exports = {
     // send the selected options / resp back to the client
 }
 
+
 // search categories for MVP: Location, (3) Food Genres, Veg (y/n), by rating
 
+
+//sample current request body from client:
+    // search req body { location: 'boston',
+    //   opt1: 'indian',
+    //   opt2: 'italian',
+    //   opt3: 'american',
+    //   mealtime: 'breakfast',
+    //   preference: 'no',
+    //   searchBy: 'Stars' }


### PR DESCRIPTION
responds to clients search request for restaurants. routes to the restaurant search controller, which then triggers a call to yelp and sends resp immediately to client. 
currently, this only factors in the location and opt1 from the request. yelp requires certain spellings for filters, so here is one example that will work just on your input:
location: boston
option 1: greek
 do not capitalize or have spaces, some criteria, like san francisco, need to be handled differently.. so just use the suggested for now. 